### PR TITLE
Fix duplicate import in MRA CUDA loader

### DIFF
--- a/src/transformers/models/mra/modeling_mra.py
+++ b/src/transformers/models/mra/modeling_mra.py
@@ -70,8 +70,6 @@ def load_cuda_kernels():
 
     cuda_kernel = load("cuda_kernel", src_files, verbose=True)
 
-    import cuda_kernel
-
 
 cuda_kernel = None
 


### PR DESCRIPTION
## Summary
- remove leftover `import cuda_kernel` statement which shadowed the CUDA extension module

## Testing
- `ruff check src/transformers/models/mra/modeling_mra.py --fix`
- `black src/transformers/models/mra/modeling_mra.py --line-length 119` *(fails to preserve docstring; manual correction applied)*
- `pytest tests/models/mra/test_modeling_mra.py::MraModelTest::test_model_forward -q` *(fails: ModuleNotFoundError: No module named 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_68484f169f0083229cdd34d2ca759f8e